### PR TITLE
Use urdfdom_headers::urdfdom_headers and alphabetize deps

### DIFF
--- a/sdformat_urdf/CMakeLists.txt
+++ b/sdformat_urdf/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(sdformat9 REQUIRED)
-find_package(urdfdom_headers REQUIRED)
+find_package(urdfdom_headers 1.0.6 REQUIRED)
 find_package(urdf_parser_plugin REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
@@ -34,7 +34,6 @@ target_include_directories(sdformat_urdf
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
-    ${urdfdom_headers_INCLUDE_DIRS}
 )
 
 # Add sdformat_urdf_plugin module library
@@ -47,10 +46,15 @@ target_link_libraries(sdformat_urdf_plugin PRIVATE
   sdformat_urdf
   tinyxml2::tinyxml2
   urdf_parser_plugin::urdf_parser_plugin
+  urdfdom_headers::urdfdom_headers
 )
 
-ament_export_dependencies(urdfdom_headers)
+ament_export_dependencies(pluginlib)
+ament_export_dependencies(rcutils)
 ament_export_dependencies(sdformat9)
+ament_export_dependencies(tinyxml2)
+ament_export_dependencies(urdf_parser_plugin)
+ament_export_dependencies(urdfdom_headers)
 
 install(TARGETS sdformat_urdf EXPORT sdformat_urdf-export
   ARCHIVE DESTINATION lib

--- a/sdformat_urdf/package.xml
+++ b/sdformat_urdf/package.xml
@@ -22,8 +22,15 @@
 
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>rcutils</build_depend>
   <build_depend>tinyxml2_vendor</build_depend>
   <build_depend>urdf_parser_plugin</build_depend>
+
+  <build_export_depend>liburdfdom-headers-dev</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
+  <build_export_depend>rcutils</build_export_depend>
+  <build_export_depend>tinyxml2_vendor</build_export_depend>
+  <build_export_depend>urdf_parser_plugin</build_export_depend>
 
   <exec_depend>tinyxml2_vendor</exec_depend>
   <exec_depend>urdf_parser_plugin</exec_depend>


### PR DESCRIPTION
Now that urdfdom_headers exports a modern CMake target, this PR makes `sdformat_urdf` use it.

I also alphabetized dependencies, and exported all dependencies in case the exported CMake target used [`$<LINK_ONLY:...>` ](https://cmake.org/cmake/help/v3.6/manual/cmake-generator-expressions.7.html#output-expressions) on the privately linked targets.

Context: https://github.com/ros/urdfdom_headers/issues/73#issuecomment-1088968959