### PR TITLE
sdformat12 support

### DIFF
--- a/sdformat_urdf/CMakeLists.txt
+++ b/sdformat_urdf/CMakeLists.txt
@@ -14,18 +14,35 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(sdformat9 REQUIRED)
 find_package(urdfdom_headers 1.0.6 REQUIRED)
 find_package(urdf_parser_plugin REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
+
+# Figure out which version of SDFormat we're using
+set(sdformat_max 12)
+set(sdformat_min 9)
+foreach(major RANGE ${sdformat_max} ${sdformat_min})
+  find_package(sdformat${major} QUIET)
+  if(sdformat${major}_FOUND)
+    set(sdformat_FOUND 1)
+    set(sdformat_major ${major})
+    break()
+  endif()
+endforeach()
+
+if(NOT sdformat_FOUND)
+  message(WARNING "Could not find any version of sdformat between ${sdformat_max} and ${sdformat_min}")
+  # This will fail, but at least it's an informative error message
+  find_package(sdformat${sdformat_max} REQUIRED)
+endif()
 
 # Add sdformat_urdf shared library
 add_library(sdformat_urdf SHARED
   src/sdformat_urdf.cpp
 )
 target_link_libraries(sdformat_urdf PUBLIC
-    sdformat9::sdformat9
+  sdformat${sdformat_major}::sdformat${sdformat_major}
   urdfdom_headers::urdfdom_headers
 )
 target_link_libraries(sdformat_urdf PRIVATE
@@ -51,7 +68,7 @@ target_link_libraries(sdformat_urdf_plugin PRIVATE
 
 ament_export_dependencies(pluginlib)
 ament_export_dependencies(rcutils)
-ament_export_dependencies(sdformat9)
+ament_export_dependencies(sdformat${sdformat_major})
 ament_export_dependencies(tinyxml2)
 ament_export_dependencies(urdf_parser_plugin)
 ament_export_dependencies(urdfdom_headers)

--- a/sdformat_urdf/src/sdformat_urdf.cpp
+++ b/sdformat_urdf/src/sdformat_urdf.cpp
@@ -66,6 +66,7 @@ sdformat_urdf::sdf_to_urdf(const sdf::Root & sdf_dom, sdf::Errors & errors)
       "SDFormat xml has a world; but only a single model is supported");
     return nullptr;
   }
+#if SDF_MAJOR_VERSION < 12
   if (0u == sdf_dom.ModelCount()) {
     errors.emplace_back(
       sdf::ErrorCode::STRING_READ,
@@ -78,8 +79,11 @@ sdformat_urdf::sdf_to_urdf(const sdf::Root & sdf_dom, sdf::Errors & errors)
       "SDFormat xml has multiple models; but only a single model is supported");
     return nullptr;
   }
-
   return convert_model(*sdf_dom.ModelByIndex(0), errors);
+#else
+  return convert_model(*sdf_dom.Model(), errors);
+#endif
+
 }
 
 urdf::ModelInterfaceSharedPtr


### PR DESCRIPTION
This is needed for releasing into ROS Rolling on Jammy, and for ROS Humble support.

This is enough to build against `sdformat12`, but there are lots of test failures to resolve.


