### PR TITLE
Support Gazebo Garden

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ See the [README in the `sdformat_urdf` package](./sdformat_urdf/README.md) for m
   * provides a library and a `urdf_parser_plugin` using that library to convert SDFormat XML to URDF C++ DOM structures
 * [`sdformat_test_files`](./sdformat_test_files/README.md)
   * provides SDFormat models using different parts of the SDFormat XML specification for testing
+
+## Version combinations
+
+This package can be compiled against versions of libSDFormat.
+
+Set the `GZ_VERSION` environment variable to match the libSDFormat version you'd like to compile against.
+For example:
+
+    export GZ_VERSION=fortress
+
+> You only need to set this variable when compiling, not when running.
+ROS version | Gazebo version | libSDFormat version | Branch | Binaries hosted at
+-- | -- | -- | -- | --
+Galactic | Citadel | 9.x | [galactic](https://github.com/ros/ros_ign/tree/galactic) | https://packages.ros.org
+Galactic | Edifice | 11.x | [galactic](https://github.com/ros/ros_ign/tree/galactic) | only from source
+Galactic | Fortress | 12.x | [galactic](https://github.com/ros/ros_ign/tree/galactic) | only from source
+Humble | Fortress | 12.x | [ros2](https://github.com/ros/ros_ign/tree/ros2) | https://packages.ros.org
+Humble | Garden | 13.x | [ros2](https://github.com/ros/ros_ign/tree/ros2) | only from source
+Rolling | Fortress | 12.x | [ros2](https://github.com/ros/ros_ign/tree/ros2) | https://packages.ros.org
+Rolling | Garden | 13.x | [ros2](https://github.com/ros/ros_ign/tree/ros2) | only from source

--- a/sdformat_urdf/CMakeLists.txt
+++ b/sdformat_urdf/CMakeLists.txt
@@ -14,18 +14,49 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(sdformat12 REQUIRED)
 find_package(urdfdom_headers 1.0.6 REQUIRED)
 find_package(urdf_parser_plugin REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
+
+# Default to Fortress
+set(SDF_VER 12)
+
+# If the user didn't specify a GZ distribution, pick the one matching the ROS distribution according to REP 2000
+if(NOT DEFINED ENV{GZ_VERSION} AND DEFINED ENV{ROS_DISTRO})
+  if("$ENV{ROS_DISTRO}" STREQUAL "humble")
+    set(ENV{GZ_VERSION} "fortress")
+  endif()
+endif()
+
+# Find libsdformat matching the picked GZ distribution
+if("$ENV{GZ_VERSION}" STREQUAL "fortress")
+  find_package(sdformat12 REQUIRED)
+  set(SDF_VER ${sdformat12_VERSION_MAJOR})
+  message(STATUS "Compiling against Gazebo Fortress (libSDFormat 12)")
+elseif("$ENV{GZ_VERSION}" STREQUAL "garden")
+  find_package(sdformat13 REQUIRED)
+  set(SDF_VER ${sdformat13_VERSION_MAJOR})
+  message(STATUS "Compiling against Gazebo Garden (libSDFormat 13)")
+# No GZ distribution specified, find any version of libsdformat we can
+else()
+  foreach(major RANGE 13 9)
+    find_package(sdformat${major} QUIET)
+    if(sdformat${major}_FOUND)
+      # Next `find_package` call will be a noop
+      set(SDF_VER ${major})
+      message(STATUS "Compiling against libSDFormat ${major}")
+      break()
+    endif()
+  endforeach()
+endif()
 
 # Add sdformat_urdf shared library
 add_library(sdformat_urdf SHARED
   src/sdformat_urdf.cpp
 )
 target_link_libraries(sdformat_urdf PUBLIC
-    sdformat12::sdformat12
+    sdformat${SDF_VER}::sdformat${SDF_VER}
   urdfdom_headers::urdfdom_headers
 )
 target_link_libraries(sdformat_urdf PRIVATE
@@ -51,7 +82,7 @@ target_link_libraries(sdformat_urdf_plugin PRIVATE
 
 ament_export_dependencies(pluginlib)
 ament_export_dependencies(rcutils)
-ament_export_dependencies(sdformat12)
+ament_export_dependencies(sdformat${SDF_VER})
 ament_export_dependencies(tinyxml2)
 ament_export_dependencies(urdf_parser_plugin)
 ament_export_dependencies(urdfdom_headers)

--- a/sdformat_urdf/package.xml
+++ b/sdformat_urdf/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>sdformat_urdf</name>
   <version>1.0.1</version>
   <description>
@@ -17,7 +17,15 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
 
-  <depend>sdformat12</depend>
+  <!-- Fortress (default) -->
+  <depend condition="$ROS_DISTRO == 'humble'">sdformat12</depend>
+  <depend condition="$ROS_DISTRO == 'rolling'">sdformat12</depend>
+  <depend condition="$GZ_VERSION == fortress">sdformat12</depend>
+  <depend condition="$GZ_VERSION == ''">sdformat12</depend>
+
+  <!-- Garden -->
+  <depend condition="$GZ_VERSION == garden">sdformat13</depend>
+
   <depend>urdf</depend>
 
   <build_depend>liburdfdom-headers-dev</build_depend>

--- a/sdformat_urdf/test/joint_tests.cpp
+++ b/sdformat_urdf/test/joint_tests.cpp
@@ -17,6 +17,8 @@
 #include <urdf_model/types.h>
 #include <sdformat_urdf/sdformat_urdf.hpp>
 
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
 #include <sdf/Types.hh>
 
 #include "sdf_paths.hpp"

--- a/sdformat_urdf/test/material_tests.cpp
+++ b/sdformat_urdf/test/material_tests.cpp
@@ -18,6 +18,7 @@
 #include <urdf_model/types.h>
 #include <sdformat_urdf/sdformat_urdf.hpp>
 
+#include <ignition/math/Vector4.hh>
 #include <sdf/Types.hh>
 
 #include "sdf_paths.hpp"


### PR DESCRIPTION
This PR makes it possible to compile the `ros2` branch against Gazebo Garden, which will be released in September.

I used the same approach from the `galactic` branch introduced in #8. To compile against Garden, `export GZ_VERSION=garden` before compiling.

When compiling against Garden, warnings will be printed complaining about the use of `ignition` in headers and namespaces, as opposed to `gz`. I think it's easier to leave them there for now. We'll soon be adding optional `gz` headers and namespaces to Citadel and Fortress, so that downstream users can use `gz` across all versions. Once that's available, it should be easier to migrate to use `gz` everywhere instead of conditionally using `ignition` or `gz` according to the version.

Garden is currently only available from sources or nightlies. I didn't find a way to inject OSRF's nightly packages into `action-ros-ci` like we do [here](https://github.com/gazebosim/ros_gz/blob/d94e7c7731b22bb5e0e2532312a881e0b49181cc/.github/workflows/build-and-test.sh#L13-L20) though. Building all dependencies from source using a repos file should be doable, but it make CI take quite a long time. So I'm not sure if there's a good way of testing Garden for this package right now.

