### PR TITLE
Handle model:// path in URI

### DIFF
--- a/sdformat_urdf/src/resolve_model_uri.hpp
+++ b/sdformat_urdf/src/resolve_model_uri.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef URI_RESOLVE_HPP_
-#define URI_RESOLVE_HPP_
+#ifndef RESOLVE_MODEL_URI_HPP_
+#define RESOLVE_MODEL_URI_HPP_
 
 #include <string.h>
 #include <string>
@@ -44,21 +44,22 @@ std::unordered_map<std::string, std::string> gz_models()
         "GAZEBO_MODEL_PATH",
         "SDF_PATH"})
   {
-    const auto paths{std::getenv(env)};
-    if(!paths)
+    const std::string paths{std::getenv(env)};
+    if(paths.empty())
       continue;
 
-    char ** save_ptr{};
-    char * path = strtok_r(paths, ":", save_ptr);
-    while (path) {
-      fs::path root(path);
-     if (fs::exists(root)) {
-        for (const auto & model : fs::directory_iterator(root)) {
+    std::istringstream iss{paths};
+    std::string path;
+
+    while (std::getline(iss, path, ':')) {
+      const fs::path modelDirectory(path);
+      if (fs::exists(modelDirectory)) {
+        for (const auto & model : fs::directory_iterator(modelDirectory)) {
           if (model.is_directory() && fs::exists(model.path() / "model.sdf")) {
             models[model.path().filename()] = model.path();
+          }
         }
       }
-      path = strtok_r(nullptr, ":", save_ptr);
     }
   }
   return models;
@@ -86,11 +87,11 @@ resolveURI(const std::string &uri)
   if(path == models.end())
     return uri;
 
-  const auto rel_path{model_path.substr(slash, model_path.npos)};
+  const auto relativePath{model_path.substr(slash, model_path.npos)};
 
-  return "file://" + path->second + rel_path;
+  return "file://" + path->second + relativePath;
 }
 }  // namespace sdformat_urdf
 
 
-#endif  // URI_RESOLVE_HPP_
+#endif  // RESOLVE_MODEL_URI_HPP_

--- a/sdformat_urdf/src/sdformat_urdf.cpp
+++ b/sdformat_urdf/src/sdformat_urdf.cpp
@@ -32,7 +32,7 @@
 #include <sdf/Visual.hh>
 
 #include "sdformat_urdf/sdformat_urdf.hpp"
-#include "uri_resolve.hpp"
+#include "resolve_model_uri.hpp"
 
 namespace sdformat_urdf
 {

--- a/sdformat_urdf/src/sdformat_urdf.cpp
+++ b/sdformat_urdf/src/sdformat_urdf.cpp
@@ -32,6 +32,7 @@
 #include <sdf/Visual.hh>
 
 #include "sdformat_urdf/sdformat_urdf.hpp"
+#include "uri_resolve.hpp"
 
 namespace sdformat_urdf
 {
@@ -624,7 +625,7 @@ sdformat_urdf::convert_geometry(const sdf::Geometry & sdf_geometry, sdf::Errors 
     // resolve the filename - which may be a URI - to the mesh resource.
     // Pass it here unmodified, ignoring that SDFormat relative paths may not
     // be resolvable this way.
-    urdf_mesh->filename = uri;
+    urdf_mesh->filename = resolveURI(uri);
 
     urdf_mesh->scale.x = sdf_geometry.MeshShape()->Scale().X();
     urdf_mesh->scale.y = sdf_geometry.MeshShape()->Scale().Y();

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -79,9 +79,9 @@ resolveURI(const std::string &uri)
   const auto models{gz_models()};
   const auto model_path{uri.substr(sep+3, uri.npos)};
   const auto slash{model_path.find('/')};
-  if(slash == model_path.npos)
+  if (slash == model_path.npos) {
     return uri;
-
+  }
   const auto path{models.find(model_path.substr(0, slash))};
   if(path == models.end())
     return uri;

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -1,4 +1,17 @@
 // Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef URI_RESOLVE_HPP_
 #define URI_RESOLVE_HPP_
 

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -48,10 +48,9 @@ std::unordered_map<std::string, std::string> gz_models()
     if(!paths)
       continue;
 
-    char** save_ptr{};
-    char* path = strtok_r(paths, ":", save_ptr);
-    while(path)
-    {
+    char ** save_ptr{};
+    char * path = strtok_r(paths, ":", save_ptr);
+    while (path) {
       fs::path root(path);
       if(fs::exists(root))
       {

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -38,11 +38,11 @@ std::unordered_map<std::string, std::string> gz_models()
   // there seem to be many possible environment variables to get models?
   // https://github.com/gazebosim/gz-sim/pull/172
   // no idea how they should be ordered
-  for(auto env : {
-      "IGN_GAZEBO_RESOURCE_PATH",
-      "GZ_SIM_RESOURCE_PATH",
-      "GAZEBO_MODEL_PATH",
-      "SDF_PATH"})
+  for (auto env : {
+        "IGN_GAZEBO_RESOURCE_PATH",
+        "GZ_SIM_RESOURCE_PATH",
+        "GAZEBO_MODEL_PATH",
+        "SDF_PATH"})
   {
     const auto paths{std::getenv(env)};
     if(!paths)

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -1,0 +1,84 @@
+#ifndef SDFORMAT_URDF_URI_RESOLVE_HPP
+#define SDFORMAT_URDF_URI_RESOLVE_HPP
+
+#include "sdformat_urdf/visibility_control.hpp"
+#include <string>
+#include <string.h>
+#include <vector>
+#include <filesystem>
+#include <unordered_map>
+
+#include <iostream>
+
+namespace sdformat_urdf
+{
+
+namespace
+{
+
+/// \brief Get the list of available models
+std::unordered_map<std::string, std::string> gz_models()
+{
+  namespace fs = std::filesystem;
+  std::unordered_map<std::string, std::string> models;
+
+  // there seem to be many possible environment variables to get models?
+  // https://github.com/gazebosim/gz-sim/pull/172
+  // no idea how they should be ordered
+  for(auto env: {
+      "IGN_GAZEBO_RESOURCE_PATH",
+      "GZ_SIM_RESOURCE_PATH",
+      "GAZEBO_MODEL_PATH",
+      "SDF_PATH"})
+  {
+    const auto paths{std::getenv(env)};
+    if(!paths)
+      continue;
+
+    char* path = strtok(paths, ":");
+    while(path)
+    {
+      fs::path root(path);
+      if(fs::exists(root))
+      {
+        for(const auto &model: fs::directory_iterator(root))
+        {
+          if(model.is_directory() && fs::exists(model.path() / "model.sdf"))
+            models[model.path().filename()] = model.path();
+        }
+      }
+      path = strtok(nullptr, ":");
+    }
+  }
+  return models;
+}
+}
+
+
+/// \brief Get a SDF-formatted mesh URI and returns the absolute path to it
+//SDFORMAT_URDF_PUBLIC
+std::string resolveURI(const std::string &uri)
+{
+  // URDF is fine with package:// or file://
+  const auto sep{uri.find("://")};
+  if(uri.substr(0, sep) != "model")
+    return uri;
+
+  static const auto models{gz_models()};
+  const auto model_path{uri.substr(sep+3, uri.npos)};
+  const auto slash{model_path.find('/')};
+  if(slash == model_path.npos)
+    return uri;
+
+  const auto path{models.find(model_path.substr(0, slash))};
+  if(path == models.end())
+    return uri;
+
+  const auto rel_path{model_path.substr(slash, model_path.npos)};
+
+  return "file://" + path->second + rel_path;
+}
+}
+
+
+#endif // SDFORMAT_URDF_URI_RESOLVE_HPP

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -17,6 +17,7 @@ namespace
 {
 
 /// \brief Get the list of available models
+SDFORMAT_URDF_LOCAL
 std::unordered_map<std::string, std::string> gz_models()
 {
   namespace fs = std::filesystem;
@@ -56,8 +57,9 @@ std::unordered_map<std::string, std::string> gz_models()
 
 
 /// \brief Get a SDF-formatted mesh URI and returns the absolute path to it
-//SDFORMAT_URDF_PUBLIC
-std::string resolveURI(const std::string &uri)
+SDFORMAT_URDF_PUBLIC
+std::string
+resolveURI(const std::string &uri)
 {
   // URDF is fine with package:// or file://
   const auto sep{uri.find("://")};

--- a/sdformat_urdf/src/uri_resolve.hpp
+++ b/sdformat_urdf/src/uri_resolve.hpp
@@ -52,11 +52,9 @@ std::unordered_map<std::string, std::string> gz_models()
     char * path = strtok_r(paths, ":", save_ptr);
     while (path) {
       fs::path root(path);
-      if(fs::exists(root))
-      {
-        for(const auto &model : fs::directory_iterator(root))
-        {
-          if(model.is_directory() && fs::exists(model.path() / "model.sdf"))
+     if (fs::exists(root)) {
+        for (const auto & model : fs::directory_iterator(root)) {
+          if (model.is_directory() && fs::exists(model.path() / "model.sdf")) {
             models[model.path().filename()] = model.path();
         }
       }


### PR DESCRIPTION
Hi,

This PR is to convert URI's starting with `model://` to absolute paths, by using classical Gazebo environment variables.

While it does not answer all cases (http link / relative path), many models just rely on `model://` meshes which are resolved here.

I am not sure on the order the environment variables should be processed ([see here](https://github.com/oKermorgant/sdformat_urdf/blob/23a94626ac56120efaf0ef2cc6ba7ae4fcb97171/sdformat_urdf/src/uri_resolve.hpp#L26)).