### PR TITLE
Create sdformat_urdf_plugin as SHARED instead of MODULE for macOS compatibility

### DIFF
--- a/sdformat_urdf/CMakeLists.txt
+++ b/sdformat_urdf/CMakeLists.txt
@@ -69,7 +69,9 @@ target_include_directories(sdformat_urdf
 )
 
 # Add sdformat_urdf_plugin module library
-add_library(sdformat_urdf_plugin MODULE
+# not actually a MODULE as workaround for 
+# https://github.com/ros/pluginlib/issues/200
+add_library(sdformat_urdf_plugin SHARED
   src/sdformat_urdf_plugin.cpp
 )
 target_link_libraries(sdformat_urdf_plugin PRIVATE

--- a/sdformat_urdf/CMakeLists.txt
+++ b/sdformat_urdf/CMakeLists.txt
@@ -69,7 +69,7 @@ target_include_directories(sdformat_urdf
 )
 
 # Add sdformat_urdf_plugin module library
-# not actually a MODULE as workaround for 
+# not actually a MODULE as workaround for
 # https://github.com/ros/pluginlib/issues/200
 add_library(sdformat_urdf_plugin SHARED
   src/sdformat_urdf_plugin.cpp


### PR DESCRIPTION
Technically speaking, when creating a library is only meant to be opened via `dlopen` (and not linked at link time) `MODULE` is instead the correct library type. However, this does not work in pluginlib (see https://github.com/ros/pluginlib/issues/200), so as a workaround to get this plugin to work on macOS, we change `sdformat_urdf_plugin`  to be a `SHARED`  library, not a `MODULE`  library. This also is aligned with what is done with the urdf_parser (see https://github.com/ros2/urdf/blob/1d257eb6a3fa34593c0da67f5d16cd0155d7d91b/urdf/CMakeLists.txt#L58). On Windows and Linux, changing from MODULE to SHARED does not change anything, as far as I know.

A similar issue on Gazebo side is https://github.com/gazebosim/gazebo-classic/issues/800 .
