### PR TITLE
Fix CI by bumping `setup-ros` to 0.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,10 @@ jobs:
     env:
        GAZEBO_VERSION: ${{ matrix.gazebo-version }}
     steps:
-      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros-distro }}
       - name: Build and test all packages
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: ${{ matrix.ros-distro }}
-


### PR DESCRIPTION
CI for https://github.com/ros/sdformat_urdf/pull/26 is failing due to `empy` issues that are resolved in `setup-ros@0.7`