### PR TITLE
Relax the version of urdfdom_headers

### DIFF
--- a/sdformat_urdf/CMakeLists.txt
+++ b/sdformat_urdf/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(urdfdom_headers 1.0.6 REQUIRED)
+find_package(urdfdom_headers REQUIRED)
 find_package(urdf_parser_plugin REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)


### PR DESCRIPTION
The `rolling` CI Is currently failing because `urdfdom_headers` has a version mismatch:
https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__sdformat_urdf__ubuntu_noble_amd64__binary/77/console

This applies a similar change to what was done in `urdfdom`:
https://github.com/ros/urdfdom/pull/222/files