### PR TITLE
Clamp urdf material rgba values to [0, 1]

### DIFF
--- a/sdformat_urdf/src/sdformat_urdf.cpp
+++ b/sdformat_urdf/src/sdformat_urdf.cpp
@@ -391,14 +391,18 @@ sdformat_urdf::convert_link(
       // Render to color same as Gazebo's default world ignoring specular
       // color = 0.4 * ambient + 0.8 * specular
       // Color support is pretty limited in urdf, just take the ambient (color with no light)
-      urdf_material->color.r =
-        0.4 * sdf_material->Ambient().R() + 0.8 * sdf_material->Diffuse().R();
-      urdf_material->color.g =
-        0.4 * sdf_material->Ambient().G() + 0.8 * sdf_material->Diffuse().G();
-      urdf_material->color.b =
-        0.4 * sdf_material->Ambient().B() + 0.8 * sdf_material->Diffuse().B();
-      urdf_material->color.a =
-        0.4 * sdf_material->Ambient().A() + 0.8 * sdf_material->Diffuse().A();
+      urdf_material->color.r = std::clamp(
+        0.4 * sdf_material->Ambient().R() + 0.8 * sdf_material->Diffuse().R(),
+        0.0, 1.0);
+      urdf_material->color.g = std::clamp(
+        0.4 * sdf_material->Ambient().G() + 0.8 * sdf_material->Diffuse().G(),
+        0.0, 1.0);
+      urdf_material->color.b = std::clamp(
+        0.4 * sdf_material->Ambient().B() + 0.8 * sdf_material->Diffuse().B(),
+        0.0, 1.0);
+      urdf_material->color.a = std::clamp(
+        0.4 * sdf_material->Ambient().A() + 0.8 * sdf_material->Diffuse().A(),
+        0.0, 1.0);
 
       urdf_visual->material = urdf_material;
 

--- a/sdformat_urdf/test/material_tests.cpp
+++ b/sdformat_urdf/test/material_tests.cpp
@@ -16,6 +16,9 @@
 #include <gtest/gtest.h>
 #include <urdf_model/model.h>
 #include <urdf_model/types.h>
+
+#include <algorithm>
+
 #include <sdformat_urdf/sdformat_urdf.hpp>
 
 #include <gz/math/Vector4.hh>
@@ -38,10 +41,14 @@ TEST(Material, material_blinn_phong)
   urdf::VisualConstSharedPtr visual = link->visual;
   ASSERT_NE(nullptr, visual);
 
+  const gz::math::Vector4d zero{0.0, 0.0, 0.0, 0.0};
+  const gz::math::Vector4d one{1.0, 1.0, 1.0, 1.0};
   const gz::math::Vector4d ambient{0.3, 0, 0, 1};
   const gz::math::Vector4d diffuse{0, 0.3, 0, 1};
-  const gz::math::Vector4d expected_color =
+  gz::math::Vector4d expected_color =
     0.4 * ambient + 0.8 * diffuse;
+  expected_color.Max(gz::math::Vector4d::Zero);
+  expected_color.Min(gz::math::Vector4d::One);
 
   EXPECT_EQ(link->name + visual->name, visual->material->name);
   EXPECT_EQ("", visual->material->texture_filename);


### PR DESCRIPTION
The formula to convert sdf materials to urdf has a range [0, 1.2] which can cause errors when loading models, for example in Rviz. To prevent this clamp the result to [0, 1]. 

