### PR TITLE
Include urdf_world types in sdformat_urdf plugin

### DIFF
--- a/sdformat_urdf/src/sdformat_urdf_plugin.cpp
+++ b/sdformat_urdf/src/sdformat_urdf_plugin.cpp
@@ -14,6 +14,7 @@
 
 #include <rcutils/logging_macros.h>
 #include <tinyxml2.h>
+#include <urdf_world/types.h>
 #include <urdf_parser_plugin/parser.h>
 
 #include <limits>


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-sdformat-urdf.patch`, authored in RoboStack by Daisuke Nishimatsu `<nishimarudai@gmail.com>`.

The plugin includes the URDF parser plugin header and uses URDF world parser types. Including `urdf_world/types.h` directly makes that dependency explicit for toolchains that do not get the declaration transitively.